### PR TITLE
Implement STK Seen

### DIFF
--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -140,13 +140,6 @@ class STKSeenRequest : public Online::XMLRequest {
     std::string addr = ServerConfig::m_ishigami_address;
     public:
 
-    bool success = false;
-    std::string username;
-    std::string country_code;
-    std::string date;
-    std::string server_name;
-    std::string server_country;
-
     STKSeenRequest(const std::string& username) : XMLRequest(Online::RequestManager::HTTP_MAX_PRIORITY) {
         setURL(addr + "/stk-seen");
         addParameter("username", username);
@@ -158,8 +151,6 @@ class STKSeenRequest : public Online::XMLRequest {
         if (!isSuccess()) {
             Log::error("Ishigami", "Failed to get the STK Seen data.");
         };
-        
-        success = true;
     }
 };
 

--- a/src/network/server_config.hpp
+++ b/src/network/server_config.hpp
@@ -677,6 +677,15 @@ namespace ServerConfig
         "administrator. Note that the server owner basically has infinite "
         "permission level."));
 
+    SERVER_CFG_PREFIX BoolServerConfigParam m_ishigami_enabled
+        SERVER_CFG_DEFAULT(BoolServerConfigParam(true, "ishigami",
+        "Enable linaSTK's stk-seen feature. Requires the ishigami server "
+        "and linaSTK to be installed and running on local or remote server."));
+
+    SERVER_CFG_PREFIX StringServerConfigParam m_ishigami_address
+        SERVER_CFG_DEFAULT(StringServerConfigParam("http://127.0.0.1:8000", "ishigami-address",
+        "Address of the ishigami server."));
+
     SERVER_CFG_PREFIX StringServerConfigParam m_restrictions_table
         SERVER_CFG_DEFAULT(StringServerConfigParam("restrictions",
         "restrictions-table",


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

Implements the `/stk-seen` command. This is functionally similar to [linaSTK's](https://codeberg.org/linaSTK/bot) STK Seen feature, but it relies on an external server (which I call Ishigami (named after a Virtual YouTuber)) to query linaSTK's database, and thus relies on linaSTK.

This can be configured in the server config, and is enabled by default and queries http://127.0.0.1:8000 by default. Source of ishigami can be found here: https://codeberg.org/tiers-meta/ishigami