### PR TITLE
Various improvements and features

### DIFF
--- a/src/lobby/commands/stk_seen.cpp
+++ b/src/lobby/commands/stk_seen.cpp
@@ -18,36 +18,26 @@
 
 #include "stk_seen.hpp"
 #include "io/xml_node.hpp"
+#include "io/file_manager.hpp"
 #include "lobby/server_lobby_commands.hpp"
 #include "lobby/stk_command.hpp"
 #include "lobby/stk_command_context.hpp"
 #include "network/protocols/server_lobby.hpp"
+#include "network/stk_host.hpp"
+#include "network/stk_peer.hpp"
 #include "network/server_config.hpp"
-#include "online/xml_request.hpp"
-#include "online/request_manager.hpp"
+#include "utils/string_utils.hpp"
 #include <parser/argline_parser.hpp>
+#include <curl/curl.h>
 #include <string>
 
 // ========================================================================
 
-class STKSeenRequest : public Online::XMLRequest {
-    private:
-    std::string addr = ServerConfig::m_ishigami_address;
-    public:
-
-    STKSeenRequest(const std::string& username) : XMLRequest(Online::RequestManager::HTTP_MAX_PRIORITY) {
-        setURL(addr + "/stk-seen");
-        addParameter("username", username);
-    };
-    virtual void afterOperation() {
-        Online::XMLRequest::afterOperation();
-        const XMLNode* result = getXMLData();
-
-        if (!isSuccess()) {
-            Log::error("Ishigami", "Failed to get the STK Seen data.");
-        };
-    }
-};
+static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+    ((std::string*)userp)->append((char*)contents, size * nmemb);
+    return size * nmemb;
+}
 
 bool StkSeenCommand::execute(nnwcli::CommandExecutorContext* const ctx, void* const data)
 {
@@ -62,67 +52,107 @@ bool StkSeenCommand::execute(nnwcli::CommandExecutorContext* const ctx, void* co
     *parser >> playername;
     parser->parse_finish();
 
+    if (playername.length() < 3)
+    {
+	ctx->write("Player name must be at least 3 characters long");
+	ctx->flush();
+	return false;
+    }
+
     ctx->write("Checking player data...");
     ctx->flush();
 
-    // Note that if the context does not survive up to this point,
-    // this will result in an undefined behavior, since
-    // the command can receive a temporary pointer
-    std::thread([ctx, playername]() {
-        auto request = std::make_shared<STKSeenRequest>(playername);
-        Online::RequestManager::get()->addRequest(request);
+    CURL *curl;
+    CURLcode res;
+    std::string response;
+    curl = curl_easy_init();
 
-        while (!request->isDone())
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (!curl)
+    {
+        ctx->write("Error: Failed to initialize HTTP request.\n");
+        ctx->flush();
+        return false;
+    }
 
-        const XMLNode* xml = request->getXMLData();
-        if (request->isSuccess())
+    std::string post_data = "username=" + playername;
+    std::string ishigami_addr = ServerConfig::m_ishigami_address;
+    std::string full_url = ishigami_addr + "/stk-seen";
+    std::string response_string;
+    curl_easy_setopt(curl, CURLOPT_URL, full_url.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post_data.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_string);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10L);
+
+    res = curl_easy_perform(curl);
+    if (res != CURLE_OK)
+    {
+	ctx->nprintf("Error: Request failed: %s\n", 512, curl_easy_strerror(res));
+	curl_easy_cleanup(curl);
+	ctx->flush();
+	return false;
+    }
+
+    long response_code;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+    curl_easy_cleanup(curl);
+
+    XMLNode *xml;
+    xml = file_manager->createXMLTreeFromString(response_string);
+
+    if (!xml)
+    {
+	ctx->write("Error: Unexpected response from server.");
+	ctx->flush();
+	return false;
+    }
+
+    std::string rec_success;
+    bool m_success;
+    m_success = false;
+
+    xml->get("success", &rec_success);
+    m_success = (rec_success == "yes");
+
+    if (!m_success)
+    {
+	std::string api_reason;
+        std::string reason;
+
+        xml->get("info", &api_reason);
+            
+        if (api_reason == "player_not_seen")
         {
-            if (xml)
-            {
-                std::string username, country, server, server_country, date;
-                xml->get("username", &username);
-                xml->get("country", &country);
-                xml->get("server", &server);
-                xml->get("server-country", &server_country);
-                xml->get("date", &date);
-
-                ctx->nprintf("Player %s (%s) was last seen on server %s (%s) at %s", 512,
-                    username.c_str(), country.c_str(), server.c_str(),
-                    server_country.c_str(), date.c_str());
-                ctx->flush();
-            }
+            reason = StringUtils::insertValues("Player %s has not been seen on any server recently.", playername);
         }
+        else if (api_reason == "sql_error")
+        {
+            reason = "SQL query failed. Please contact the administrator";
+        }
+	else if (api_reason == "optout")
+	{
+	    reason = "This player has opted out of this feature";
+	}
         else
         {
-            std::string api_reason;
-            std::string reason;
-
-            if (xml)
-                xml->get("info", &api_reason);
-            
-            if (api_reason == "player_not_seen")
-            {
-                reason = StringUtils::insertValues("Player %s has not been seen on any server recently.", playername);
-            }
-            else if (api_reason == "name_too_short")
-            {
-                reason = "Username must be at least 3 characters";
-            }
-            else if (api_reason == "sql_error")
-            {
-                reason = "SQL query failed. Please contact the administrator";
-            }
-            else
-            {
-                reason = "Unspecified error";
-            }
-
-            ctx->write("Failed to get player data: ");
-            ctx->write(reason);
-            ctx->flush();
+            reason = "Unspecified error";
         }
-    }).detach();
 
+	ctx->write("Failed to get player data: ");
+        ctx->write(reason);
+        ctx->flush();
+	return false;
+    }
+
+    std::string username, country, server, server_country, date;
+    xml->get("username", &username);
+    xml->get("country", &country);
+    xml->get("server", &server);
+    xml->get("server-country", &server_country);
+    xml->get("date", &date);
+    ctx->nprintf("Player %s (%s) was last seen on server %s (%s) at %s", 512,
+                    username.c_str(), country.c_str(), server.c_str(),
+                    server_country.c_str(), date.c_str());
+    ctx->flush();
     return true;
 }

--- a/src/lobby/commands/stk_seen_optout.cpp
+++ b/src/lobby/commands/stk_seen_optout.cpp
@@ -1,0 +1,127 @@
+//
+//  SuperTuxKart - a fun racing game with go-kart
+//  Copyright (C) 2013-2015 SuperTuxKart-Team
+//  Copyright (C) 2025 the linaSTK authors (https://codeberg.org/linaSTK)
+//
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 3
+//  of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+#include "stk_seen_optout.hpp"
+#include "io/xml_node.hpp"
+#include "io/file_manager.hpp"
+#include "lobby/server_lobby_commands.hpp"
+#include "lobby/stk_command.hpp"
+#include "lobby/stk_command_context.hpp"
+#include "network/protocols/server_lobby.hpp"
+#include "network/stk_host.hpp"
+#include "network/stk_peer.hpp"
+#include "network/server_config.hpp"
+#include "network/protocols/server_lobby.hpp"
+#include "utils/string_utils.hpp"
+#include <parser/argline_parser.hpp>
+#include <curl/curl.h>
+#include <string>
+
+static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+    ((std::string*)userp)->append((char*)contents, size * nmemb);
+    return size * nmemb;
+}
+
+bool StkSeenOptOutCommand::execute(nnwcli::CommandExecutorContext* const ctx, void* const data)
+{
+    STK_CTX(stk_ctx, ctx);
+
+    auto parser = ctx->get_parser();
+    parser->parse_finish();
+
+    ServerLobby* const lobby = stk_ctx->get_lobby();
+    if (!lobby) return false;
+
+    STKPeer* player_peer = stk_ctx->get_peer();
+    if (!player_peer || !player_peer->hasPlayerProfiles())
+    {
+        ctx->write("Error: Could not get player information.\n");
+        ctx->flush();
+        return false;
+    }
+    std::string player_name = StringUtils::wideToUtf8(player_peer->getPlayerProfiles()[0]->getName());
+
+    CURL *curl;
+    CURLcode res;
+    std::string response;
+    curl = curl_easy_init();
+
+    if (!curl)
+    {
+        ctx->write("Error: Failed to initialize HTTP request.\n");
+        ctx->flush();
+        return false;
+    }
+
+    std::string post_data = "username=" + player_name;
+    std::string ishigami_addr = ServerConfig::m_ishigami_address;
+    std::string full_url = ishigami_addr + "/stk-seen-opt-toggle";
+    std::string response_string;
+    curl_easy_setopt(curl, CURLOPT_URL, full_url.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post_data.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_string);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10L);
+
+    res = curl_easy_perform(curl);
+    if (res != CURLE_OK)
+    {
+        ctx->nprintf("Error: Request failed: %s\n", 512, curl_easy_strerror(res));
+        curl_easy_cleanup(curl);
+        ctx->flush();
+        return false;
+    }
+
+    long response_code;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+    curl_easy_cleanup(curl);
+
+    XMLNode *xml;
+    xml = file_manager->createXMLTreeFromString(response_string);
+
+    if (!xml)
+    {
+        ctx->write("Error: Unexpected response from server.");
+        ctx->flush();
+        return false;
+    }
+
+    std::string rec_success;
+    bool m_success;
+    m_success = false;
+
+    xml->get("success", &rec_success);
+    m_success = (rec_success == "yes");
+
+    std::string reason;
+    xml->get("info", &reason);
+
+    if (!m_success)
+    {
+	ctx->nprintf("Failed to opt in/out of STK seen: %s", 512, reason);
+	ctx->flush();
+	return false;
+    }
+
+    ctx->write(reason);
+    ctx->flush();
+
+    return true;
+}

--- a/src/lobby/commands/stk_seen_optout.hpp
+++ b/src/lobby/commands/stk_seen_optout.hpp
@@ -1,0 +1,42 @@
+//
+//  SuperTuxKart - a fun racing game with go-kart
+//  Copyright (C) 2013-2015 SuperTuxKart-Team
+//  Copyright (C) 2025 the linaSTK authors (https://codeberg.org/linaSTK)
+//
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 3
+//  of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+#ifndef LOBBY_COMMAND_STK_SEEN_OPTOUT_HPP
+#define LOBBY_COMMAND_STK_SEEN_OPTOUT_HPP
+
+#include "lobby/stk_command.hpp"
+#include "network/moderation_toolkit/server_permission_level.hpp"
+#include "utils/cpp2011.hpp"
+
+class StkSeenOptOutCommand : public STKCommand
+{
+    ServerPermissionLevel m_min_veto = PERM_PLAYER;
+public:
+    StkSeenOptOutCommand() : STKCommand(false)
+    {
+        // The command's "main" alias.
+        m_name = "stk-seen-optout";
+        m_args = {};
+        m_description = "Opt in/out of the STK Seen feature.";
+    }
+
+    virtual bool execute(nnwcli::CommandExecutorContext* context, void* data) OVERRIDE;
+};
+
+#endif // LOBBY_COMMAND_STK_SEEN_OPT_OUT_HPP

--- a/src/lobby/server_lobby_commands.cpp
+++ b/src/lobby/server_lobby_commands.cpp
@@ -43,6 +43,7 @@
 #include "lobby/commands/spectate.hpp"
 #include "lobby/commands/speedstats.hpp"
 #include "lobby/commands/stk_seen.hpp"
+#include "lobby/commands/stk_seen_optout.hpp"
 #include "lobby/commands/unban.hpp"
 #include "lobby/commands/vote.hpp"
 #include "lobby/commands/help.hpp"
@@ -245,6 +246,8 @@ void ServerLobbyCommands::registerCommands()
     {
         m_executor.register_command(std::make_shared<StkSeenCommand>());
         m_executor.add_alias("seen", "stk-seen");
+	m_executor.register_command(std::make_shared<StkSeenOptOutCommand>());
+	m_executor.add_alias("toggle-antitrack", "stk-seen-optout");
     }
     m_executor.register_command(std::make_shared<DatetimeCommand>());
     m_executor.add_alias("date", "datetime");


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

New feature: allow users to opt out of the STK Seen feature using `stk-seen-optout` or `toggle-antitrack` commands. (Backend change: https://codeberg.org/tiers-meta/ishigami/commit/663f9e57460dbd34e0da648956313a2e361e3c20)
Refactor: Use the curl library directly instead of `Online::XMLRequest` and `Online::RequestManager` to (hopefully) prevent any possible crashes.
