### PR TITLE
Decode XML-encoded strings in stk-seen.

### DIFF
--- a/src/lobby/commands/stk_seen.cpp
+++ b/src/lobby/commands/stk_seen.cpp
@@ -146,17 +146,17 @@ bool StkSeenCommand::execute(nnwcli::CommandExecutorContext* const ctx, void* co
 			return;
 		}
 
-		std::string username, country, server, server_country, date;
-		xml->get("username", &username);
-		xml->get("country", &country);
-		xml->get("server", &server);
-		xml->get("server-country", &server_country);
-		xml->get("date", &date);
+		irr::core::stringw username, country, server, server_country, date;
+		xml->getAndDecode("username", &username);
+		xml->getAndDecode("country", &country);
+		xml->getAndDecode("server", &server);
+		xml->getAndDecode("server-country", &server_country);
+		xml->getAndDecode("date", &date);
 
 		if (auto peer_locked = peer_wk.lock())
 		{
-			std::string msg = StringUtils::insertValues(
-				"Player %s (%s) was last seen on server %s (%s) at %s",
+			irr::core::stringw msg = StringUtils::insertValues(
+				irr::core::stringw("Player %s (%s) was last seen on server %s (%s) at %s"),
 				username, country, server, server_country, date);
 			std::shared_ptr<STKPeer> peer = peer_locked;
 			lobby_raw->sendStringToPeer(msg, peer);


### PR DESCRIPTION
Haven't tested it myself but it should work.

Should fix messages with raw xml-encoded escape sequences like this:

<img width="1064" height="146" alt="image" src="https://github.com/user-attachments/assets/2a2bedac-983c-4a3a-8292-dfcaa1487b96" />

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
